### PR TITLE
ncgeodataset.delete error -- not fixed here.

### DIFF
--- a/cdm/ncdataset.m
+++ b/cdm/ncdataset.m
@@ -18,6 +18,7 @@
 %       be tweaked as needed. (For example, to enable/disable
 %       data caching.) See
 %       http://www.unidata.ucar.edu/software/netcdf-java/v4.2/javadoc/index.html
+%       Examples: ds.netcdf.toString ; ds.netcdf.getLocation ; ds.netcdf.getDetailInfo 
 %   variables = A cell array of all variables in the ncdataset. These names
 %        are used as arguments into other ncdataset methods
 %
@@ -67,6 +68,10 @@ classdef ncdataset < handle
             % If the argument is another instance of ncdataset or one of it's
             % subtypes, such as cfdataset or ncgeodataset then this creates
             % a new ncdataset that shares the underlying data.
+            %
+            % For documentation on the Java ncdataset.netcdf
+            % methods, see
+            % http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/v4.2/javadoc/ucar/nc2/dataset/NetcdfDataset.html  
             if isa(url, 'ncdataset')
                 obj.location = url.location;
                 obj.netcdf = ucar.nc2.dataset.NetcdfDataset.openDataset(url.netcdf.getLocation());
@@ -417,8 +422,9 @@ classdef ncdataset < handle
             % in legacy njtbx code...
         end
         
-        function delete(obj)
+        function B = delete(obj)
             % NCDATASET.DELETE Closes netcdf files when object NCDATASET object is disposed or leaves scope
+            B = 0;
             try
                 obj.netcdf.close()
             catch me

--- a/cdm/ncgeodataset.m
+++ b/cdm/ncgeodataset.m
@@ -613,7 +613,11 @@ classdef ncgeodataset < cfdataset
                             a = substruct('.',s(1).subs);
                             A = builtin('subsref',obj,a);
                             %                         b = substruct('.',s(2).subs,'()',s(2).subs);
-                            B = builtin('subsref',A,s(2:end));
+                            if(s(2).subs == 'close')
+                                builtin('subsref',A,s(2:end));
+                            else
+                                B = builtin('subsref',A,s(2:end));
+                            end
                         else
                             g = substruct('.',s(1).subs,'()',s(2).subs);
                             % g.type = '()';

--- a/cdm/ncvariable.m
+++ b/cdm/ncvariable.m
@@ -78,7 +78,7 @@ classdef ncvariable < handle
         end
         
         function a = get.attributes(obj)
-            % NCVARIABLE.ATTRIBUTES returns the attributes for the varaible.
+            % NCVARIABLE.ATTRIBUTES returns the attributes for the variable.
             a = obj.dataset.attributes(obj.name);
         end
         
@@ -96,13 +96,17 @@ classdef ncvariable < handle
         function v = get.name(obj)
             % NCVARIABLE.NAME Provides dynamic access to the underlying
             % netcdf datasets variable name
+            %
+            % Example:
+            %   vname=v.name % returns the name of the variable
+            %
             v = char(obj.variable.getName());
         end
         
         %%
         function n = size(obj)
             % NCVARIABLE.SIZE returns the size of the variable, including
-            % it's singleton dimensions
+            % its singleton dimensions
             n = obj.dataset.size(obj.name);
         end
         
@@ -242,7 +246,9 @@ classdef ncvariable < handle
        
         %%
         function e = end(obj, k, n)
-            % NCVARIABLE.END the last index in an indexing expression.
+            % NCVARIABLE.END the last index in an indexing
+            % expression.
+            % v.end(2) % returns the last index of the second dimension.
             % e.g.: elevation.data(end-3:end,1,1)
             n = obj.dataset.size(obj.name);
             e = n(k);
@@ -349,8 +355,10 @@ classdef ncvariable < handle
         
         %%
         function data = alldata(obj, withData)
-            % Extract all the data
-            % ---- Step 2: Add the data
+            % NCVARIABLE.ALLDATA -- extract the data or the axes
+            % v.alldata(1) % returns the data
+            % v.alldata()  % returns a structure with the axesVariables
+            %              % and their data
             if withData == 1
                 name = char(obj.variable.getName());
                 data = obj.dataset.data(name);
@@ -366,7 +374,19 @@ classdef ncvariable < handle
         
         %%
         function data = somedata(obj, withData, first, last, stride)
-            % NCGEOVARIABLE.SOMEDATA -- extract a slice of the data
+            % NCGEOVARIABLE.SOMEDATA -- extract a hyperslab of data
+            % SOMEDATA can extract a subset of data from an NCVARIABLE or
+            % the subset of the corresponding axis variables.
+            % 
+            % Example:
+            %  first=ones(length(v.size));
+            %  last=v.size;
+            %       stride=first;
+            % vd = v.somedata(1,first,last,stride); % returns data
+            % vg = v.somedata(0,first,last,stride); % returns struct w/grid
+            % 
+            % See also NCVARIABLE, NCVARIABLE.ALLDATA,
+            % NCVARIABLE.DATA, NCVARIABLE.GRID
             s = obj.dataset.size(obj.name);
             
             % Fill in missing arguments


### PR DESCRIPTION
This has the doc patches in the other pull request--I don't know git well enough to separate them.

While I was looking at the docs, I tried a geo.delete and had problems.  I doubt this patch is the best way to resolve it, since it doesn't completely fix it.  It looks like this sort of problem would extend to any void-return obj.netcdf.methods accessed through the ncgeodataset.subsref stuff.

I wonder if undeleted ncgeodatasets have caused my matlab to crash while I've been experimenting.

```
url = 'http://dods.mbari.org/cgi-bin/nph-nc/data/ssdsdata/deployments/m1/200810/OS_M1_20081008_TS.nc'
geo = ncgeodataset(url)
nm = geo.standard_name('sea_water_temperature')
geo.netcdf.close  % fails, but works post-patch
geo.delete % fails, fails silently and returns 0 post-patch
cf = cfdataset(url)
cf.delete
cf = cfdataset(url)
cf.netcdf.close %works
nc = ncdataset(url)
nc.netcdf.close % works
nc = ncdataset(url)
nc.delete  % works
```
