### PR TITLE
cdm/utilities/vis/modellook.m: Add some argument handling for modellook

### DIFF
--- a/cdm/nctoolbox-version.txt
+++ b/cdm/nctoolbox-version.txt
@@ -1,4 +1,4 @@
-GIT COMMIT:   c797e60
-GIT BRANCH:   master
-GIT DATE:     2015-03-13
-GIT DESCRIBE: nctoolbox-20140414-beta-39-gc797e60
+GIT COMMIT: 29541b3
+GIT BRANCH: (HEAD, upstream/master, upstream/integration, upstream/HEAD, modellook, master)
+GIT DATE:   2015-03-13
+GIT DESCRIBE: nctoolbox-20140414-beta-40-g29541b3

--- a/cdm/utilities/vis/modellook.m
+++ b/cdm/utilities/vis/modellook.m
@@ -3,17 +3,34 @@
 % Useful to look at 2d, 3d, and 4d variables from gridded model netcdf files.
 %
 % Usage : >> modellook(daplink, datevec)
-%             >> modellook(daplink, datenum)
+%         >> modellook(daplink, datenum)
+%         >> modellook('uri',daplink,'date',datenum,'level',1)
 %
 % NCTOOLBOX (https://github.com/nctoolbox/nctoolbox)
 %
 function [] = modellook(varargin)
-input_hash = arg2hash(varargin);
 
-dap = value4key(input_hash, 'uri'); % Required
-date = value4key(input_hash, 'date'); % Required
-level = value4key(input_hash, 'level'); % Default to 1
+if(length(varargin) > 3) % assume is a hash
+    input_hash = arg2hash(varargin);
 
+    dap = value4key(input_hash, 'uri'); % Required
+    date = value4key(input_hash, 'date'); % Required
+    level = value4key(input_hash, 'level'); % Default to 1
+else % otherwise straight arguments
+    if(nargin >=2 )
+    dap = varargin{1};
+    date = varargin{2};
+    if (nargin == 3)
+        level = varargin{3};
+    else
+        level = 1;
+    end
+    else
+        error('not enough arguments');
+    end
+end
+
+    
 if isempty(level)
     level = 1;
 end


### PR DESCRIPTION
cdm/utilities/vis/modellook.m: Add some argument handling for modellook(... uri,dates,[level]).

Modellook is written to take arguments in only 'keyword', value arguments, and this change allows a more normal calling procedure.